### PR TITLE
Add config option to determine show no stimulus message or not

### DIFF
--- a/src/main/java/com/queuedpixel/stimuluspackage/StimulusTask.java
+++ b/src/main/java/com/queuedpixel/stimuluspackage/StimulusTask.java
@@ -418,7 +418,7 @@ public class StimulusTask extends BukkitRunnable
 
             StimulusUtil.appendToFile( logFile, divider );
         }
-        else
+        else if (plugin.getConfig().getBoolean("showNoStimulusMsg"))
         {
             // send a message to all players about the lack of stimulus
             for ( UUID playerId : activeStimulusPlayers )

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -80,3 +80,8 @@ excludedPlayers:
 # Data Type: long
 # Default Value: 5 minutes (300 seconds)
 logBalancesInterval: 300
+
+# Description: Determine whether to show the message that user receives no stimulus or not
+# Data Type: boolean
+# Default value: true
+showNoStimulusMsg: true


### PR DESCRIPTION
Add config option in config.yml
Read the config to check before showing no stimulus message