### PR TITLE
Provide config properties to decide whether to show no stimulus message or not

### DIFF
--- a/src/main/java/com/queuedpixel/stimuluspackage/StimulusTask.java
+++ b/src/main/java/com/queuedpixel/stimuluspackage/StimulusTask.java
@@ -307,7 +307,7 @@ public class StimulusTask extends BukkitRunnable
                     playerWealthMap.put( playerId, playerWealthMap.get( playerId ) + payment );
                     if ( !onlinePlayerMap.containsKey( playerId )) this.plugin.addOfflineStimulus( playerId, payment );
                 }
-                else
+                else if (plugin.getConfig().getBoolean("showNormalNoStimulusMsg"))
                 {
                     Player player = onlinePlayerMap.get( playerId );
                     if ( player != null )
@@ -418,7 +418,7 @@ public class StimulusTask extends BukkitRunnable
 
             StimulusUtil.appendToFile( logFile, divider );
         }
-        else
+        else if (plugin.getConfig().getBoolean("showStrongEcoNoStimulusMsg"))
         {
             // send a message to all players about the lack of stimulus
             for ( UUID playerId : activeStimulusPlayers )

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -80,3 +80,13 @@ excludedPlayers:
 # Data Type: long
 # Default Value: 5 minutes (300 seconds)
 logBalancesInterval: 300
+
+# Description: Determine whether to show message when player receive no stimulus or not.
+# Data Type: boolean
+# Default Value: true
+showNormalNoStimulusMsg: true
+
+# Description: Determine whether to show message when player receive no stimulus or not due to strong economy.
+# Data Type: boolean
+# Default Value: true
+showStrongEcoNoStimulusMsg: true


### PR DESCRIPTION
Add 2 new properties in config.yml to allow user to decide whether or not to send player the message that user receives no stimulus.

I tried to give user the ability to customize the message to be sent. And when the configured message are empty/null , we won't show the message.
After testing I figured out that this solution won't work. The config seems to not accept empty/null value in custom config.yml file and fallback to default configuration value in the jar.
